### PR TITLE
Fix garbage sending in multiplayer

### DIFF
--- a/client/src/components/Versus.tsx
+++ b/client/src/components/Versus.tsx
@@ -341,8 +341,15 @@ const Versus: React.FC = () => {
     };
     socket.on('game:over', onGameOver);
 
-    const onGarbage = (g: number) => {
-      setPendingGarbageLeft((prev: number) => prev + (g || 0));
+    const onGarbage = (payload: any) => {
+      const amount = typeof payload === 'number'
+        ? payload
+        : Number(payload?.amount ?? 0) || 0;
+      if (!amount) {
+        // Ignore empty payloads so we do not show phantom garbage
+        return;
+      }
+      setPendingGarbageLeft((prev: number) => prev + amount);
     };
     socket.on('game:garbage', onGarbage);
     

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -330,9 +330,14 @@ io.on('connection', (socket) => {
 
     g += b2bBonus + comboBonus;
 
-    // Send garbage to all other players in room
-    for (const [sid, sp] of r.players) {
-      if (sid !== socket.id && sp.alive) io.to(sid).emit('game:garbage', g);
+    if (g > 0) {
+      const payload = { amount: g, from: socket.id, roomId };
+      const targets = [...r.players.values()]
+        .filter(pl => pl.id !== socket.id && pl.alive)
+        .map(pl => pl.id);
+      if (targets.length) {
+        io.to(targets).emit('game:garbage', payload);
+      }
     }
     saveRoom(r);
   });


### PR DESCRIPTION
## Summary
- broadcast garbage lines from the server only to alive opponents with a richer payload
- make the versus client understand the new garbage payload shape and ignore empty attacks

## Testing
- npm run build --prefix server *(fails: PostgreSQL connection refused in CI env)*
- npm run build --prefix client *(fails: existing TypeScript unused variable errors)*

------
https://chatgpt.com/codex/tasks/task_e_68e48295e420832db81881e53828cd35